### PR TITLE
Update vscode-extensions.md

### DIFF
--- a/vscode-extensions.md
+++ b/vscode-extensions.md
@@ -18,4 +18,4 @@
 * [Prettify JSON](https://marketplace.visualstudio.com/items?itemName=mohsen1.prettify-json)
 * [Thunder Client](https://marketplace.visualstudio.com/items?itemName=rangav.vscode-thunder-client)
 * [Turbo Console Log](https://marketplace.visualstudio.com/items?itemName=ChakrounAnas.turbo-console-log)
-* [vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
+* [vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components)


### PR DESCRIPTION
O link do Styled Components está invalido, foi alterado o caminho do download. (estou aprendendo Git/Github, então estou contribuindo até com .md quando encontro algo kkkkkkk)

"Styled Components has moved! Make sure you're downloading it from here"